### PR TITLE
fix(peerjs): use 1.peerjs.com as an alternative host

### DIFF
--- a/demo/shared/js/common-peerjs.js
+++ b/demo/shared/js/common-peerjs.js
@@ -1,9 +1,18 @@
 export function getPeerjsConfig() {
-  return import.meta.env.VITE_USE_LOCAL_PEER_SERVER
-    ? {
-        host: "localhost",
-        port: 9000,
-        path: "/myapp",
-      }
-    : undefined;
+  // when using the local signaling server
+  if (import.meta.env.VITE_USE_LOCAL_PEER_SERVER) {
+    return {
+      host: "localhost",
+      port: 9000,
+      path: "/myapp",
+    };
+  }
+  // default case, we use the alternate server since on some mobile carriers (orange - France)
+  // the default host 0.peerjs.com hangs on forever - see https://github.com/peers/peerjs/issues/948#issuecomment-1107437915
+  // todo what if this fix triggers the same kind of problem on other carriers ? implement some kind of balancing ?
+  return {
+    host: "1.peerjs.com",
+    port: 443,
+    path: "/",
+  };
 }


### PR DESCRIPTION
On the mobile carrier Orange - France, the connection to 0.peerjs.com hangs on forever.

@jonasgloning proposed to use alternative host 1.peerjs.com.

More infos on issue: https://github.com/peers/peerjs/issues/948#issuecomment-1107437915