### PR TITLE
fix(puppeteer): change to 0.peerjs.com

### DIFF
--- a/demo/shared/js/common-peerjs.js
+++ b/demo/shared/js/common-peerjs.js
@@ -11,7 +11,7 @@ export function getPeerjsConfig() {
   // the default host 0.peerjs.com hangs on forever - see https://github.com/peers/peerjs/issues/948#issuecomment-1107437915
   // todo what if this fix triggers the same kind of problem on other carriers ? implement some kind of balancing ?
   return {
-    host: "1.peerjs.com",
+    host: "0.peerjs.com",
     port: 443,
     path: "/",
   };


### PR DESCRIPTION
Previously set to 1.peerjs.com due to 4G problems. This host seems to be
the cause of the e2e failing - see #7.
Checked with my own iphone in 4G - This change is OK - to check with
more devices and ISPs.